### PR TITLE
Timezones hurt

### DIFF
--- a/Classes/XbAsyncExportWaiter.ps1
+++ b/Classes/XbAsyncExportWaiter.ps1
@@ -3,9 +3,9 @@
     Holds all the information about a single `.export async` command for transit through start/wait/receive.
 #>
 class XbAsyncExportWaiter {
-    [datetime]$Timestamp = [datetime]::Now
-    [ValidateNotNullOrEmpty()][datetime]$Start
-    [ValidateNotNullOrEmpty()][datetime]$End
+    [DateTimeOffset]$Timestamp = [DateTimeOffset]::Now
+    [ValidateNotNullOrEmpty()][DateTimeOffset]$Start
+    [ValidateNotNullOrEmpty()][DateTimeOffset]$End
     [string]$Prefix
     [ValidateNotNullOrEmpty()][guid]$OperationId
     [string]$State
@@ -13,7 +13,7 @@ class XbAsyncExportWaiter {
     [bigint]$SizeBytes
     [int]$NumFiles
     XbAsyncExportWaiter([PsCustomObject]$InputObject){
-        $this.Timestamp   = if($InputObject.Timestamp){$InputObject.Timestamp}else{[datetime]::Now}
+        $this.Timestamp   = if($InputObject.Timestamp){$InputObject.Timestamp}else{[DateTimeOffset]::Now}
         $this.Start       = $InputObject.Start
         $this.End         = $InputObject.End
         $this.Prefix      = $InputObject.Prefix

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -81,11 +81,12 @@ function Export-XbTable {
         }
         Write-Verbose "Initializing serial batch; IndexStart: '$IndexStart', IndexEnd: '$IndexEnd'"
         $Batches = $IndexStart .. $IndexEnd | ForEach-Object {
-            $Start = Get-Date $Days[$_]     -Format "yyyy-MM-dd hh:mm:ss"
-            $End   = Get-Date $Days[$_ + 1] -Format "yyyy-MM-dd hh:mm:ss"
-            Write-Verbose "Initializing parallel batch; IndexPosition: '$_', Start: '$Start', End: '$End'"
-            $Operation = Start-XbAsyncArchive -Start $Start -End $End @AdxTableSpec
-            $Operation.Prefix = "start=$($Days[$_].ToString("yyyy-MM-dd"))"
+            $startStr = $Days[$_].ToString('u')
+            $endStr   = $Days[$_ + 1].ToString('u')
+            $prefix   = $Days[$_].ToString("yyyy-MM-dd")
+            Write-Verbose "Initializing parallel batch; IndexPosition: '$_', Start: '$startStr', End: '$endStr'"
+            $Operation = Start-XbAsyncArchive -Start $startStr -End $endStr @AdxTableSpec
+            $Operation.Prefix = "${TimestampColumnName}=${prefix}"
             $Operation
         }
 

--- a/Functions/Receive-XbAsyncArchive.ps1
+++ b/Functions/Receive-XbAsyncArchive.ps1
@@ -26,7 +26,7 @@ function Receive-XbAsyncArchive {
 
     $Aggregate = $Blobs | ForEach-Object {$_.Length} | Measure-Object -Sum 
 
-    $Waiter.Timestamp = Get-Date -Format u
+    $Waiter.Timestamp = [DateTimeOffset]::Now
     $Waiter.SizeBytes = $Aggregate.Sum
     $Waiter.NumFiles  = $Aggregate.Count
 

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -33,8 +33,8 @@ function Start-XbAsyncArchive {
         $TimestampColumnName
     )
 
-    $startStr = $Start.ToString()
-    $endStr   = $End.ToString()
+    $startStr = $Start.ToString('u')
+    $endStr   = $End.ToString('u')
 
     $exportAsyncCmd = @(
         ".export async to table ext$TableName <|"
@@ -59,7 +59,7 @@ function Start-XbAsyncArchive {
         Write-Warning "Returned OperationId: '$($command.OperationId)' is not a GUID. "
     }
 
-    Write-Verbose "$(Get-Date -Format u): Started Operation: '$($command.OperationId)', Start: '$Start', End: '$End'"
+    Write-Verbose "$(Get-Date -Format u): Started Operation: '$($command.OperationId)', Start: '$startStr', End: '$endStr'"
 
     [XbAsyncExportWaiter][PsCustomObject]@{
         OperationId = $command.OperationId

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -9,12 +9,12 @@ function Start-XbAsyncArchive {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [datetime]
-        $Start,
+        [string]
+        $StartStr,
 
         [Parameter(Mandatory)]
-        [datetime]
-        $End,
+        [string]
+        $EndStr,
 
         [Parameter(Mandatory)]
         [string]
@@ -32,9 +32,6 @@ function Start-XbAsyncArchive {
         [string]
         $TimestampColumnName
     )
-
-    $startStr = $Start.ToString('u')
-    $endStr   = $End.ToString('u')
 
     $exportAsyncCmd = @(
         ".export async to table ext$TableName <|"
@@ -59,11 +56,11 @@ function Start-XbAsyncArchive {
         Write-Warning "Returned OperationId: '$($command.OperationId)' is not a GUID. "
     }
 
-    Write-Verbose "$(Get-Date -Format u): Started Operation: '$($command.OperationId)', Start: '$startStr', End: '$endStr'"
+    Write-Verbose "$(Get-Date -Format u): Started Operation: '$($command.OperationId)', Start: '$StartStr', End: '$EndStr'"
 
     [XbAsyncExportWaiter][PsCustomObject]@{
         OperationId = $command.OperationId
-        Start = $Start
-        End = $End
+        Start = [DateTimeOffset]$StartStr
+        End = [DateTimeOffset]$EndStr
     }
 }

--- a/Scripts/SampleUsage.ps1
+++ b/Scripts/SampleUsage.ps1
@@ -15,8 +15,8 @@ $ClusterUrl          = 'https://help.kusto.windows.net;Fed=True'
 $DatabaseName        = 'Samples'
 $TableName           = 'StormEvents'
 $TimestampColumnName = 'StartTime'
-$Start               = '2007-01-01'
-$End                 = '2008-01-01'
+$Start               = '2007-01-01 00:00:00Z'
+$End                 = '2008-01-01 00:00:00Z'
 $Step                = [timespan]'1.00:00:00'
 $Parallel            = 4
 

--- a/Scripts/SampleUsage.ps1
+++ b/Scripts/SampleUsage.ps1
@@ -1,0 +1,39 @@
+
+Push-Location $PSScriptRoot
+
+if($null -eq (Get-Module Invoke-AdxCmd -ListAvailable)){
+    Write-Error "Module 'Invoke-AdxCmd' must be present in `$env:PsModulePath."
+    return
+}
+
+Import-Module ../PsAdxArchiver.psd1
+
+$StorageAccountName  = 'mystorageaccount'
+$Container           = 'storm-events'
+$LogFile             = '~/Desktop/export.log.csv'
+$ClusterUrl          = 'https://help.kusto.windows.net;Fed=True'
+$DatabaseName        = 'Samples'
+$TableName           = 'StormEvents'
+$TimestampColumnName = 'StartTime'
+$Start               = '2007-01-01'
+$End                 = '2008-01-01'
+$Step                = [timespan]'1.00:00:00'
+$Parallel            = 4
+
+$exportSplat = @{
+    StorageAccountName  = $StorageAccountName
+    Container           = $Container
+    LogFile             = $LogFile
+    ClusterUrl          = $ClusterUrl
+    DatabaseName        = $DatabaseName
+    TableName           = $TableName
+    TimestampColumnName = $TimestampColumnName
+    Start               = $Start
+    End                 = $End
+    Step                = $Step
+    Parallel            = $Parallel
+}
+
+Export-XbTable @exportSplat -Verbose
+
+Pop-Location

--- a/Tests/New-XbBatchBounds.Tests.ps1
+++ b/Tests/New-XbBatchBounds.Tests.ps1
@@ -1,31 +1,30 @@
-#Requires -Modules @{ModuleName='PsAdxArchiver';ModuleVersion='0.0.1';Guid='6db49c4c-0073-44fe-95d8-907f056c1645'}
 #Requires -Modules @{ModuleName='Pester';MaximumVersion='4.99';Guid='a699dea5-2c73-4616-a270-1f7abb777e71'}
 
 Describe "New-XbBatchBounds creates an expected array" {
-    $Start = '2023-01-01 00:00'
-    $End = '2023-01-01 04:00'
+    $Start = [DateTimeOffset]'2023-01-01 00:00Z'
+    $End   = [DateTimeOffset]'2023-01-01 04:00Z'
     $BatchSpec = @{
         Start = $Start
         End   = $End
-        Step  = '01:00:00'
+        Step  = [timespan]'01:00:00'
     }
     $BatchBounds = New-XbBatchBounds @BatchSpec
     It "Should have the right number of batches" {
-        $BatchBounds.Count | Should -BeExactly 5
+        $BatchBounds.Count | Should -BeExactly 4
     }
     It "Should be sorted" {
-        $Test    = ($BatchBounds | ConvertTo-Json) 
-        $Control = ($BatchBounds | Sort-Object | ConvertTo-Json)
+        $Test    = $BatchBounds | ConvertTo-Csv
+        $Control = $BatchBounds | Sort-Object Start | ConvertTo-Csv
         $Test | Should -Be $Control
     }
-    It "Should have the correct first batch" {
-        $Test    = (Get-Date $BatchBounds[0] -Format u) 
-        $Control = (Get-Date $Start -Format u)
+    It "Should have the correct lower bound" {
+        $Test    = $BatchBounds[0].Start
+        $Control = $Start.ToString('u')
         $Test | Should -Be $Control
     }
-    It "Should have the correct last batch" {
-        $Test    = (Get-Date $BatchBounds[-1] -Format u) 
-        $Control = (Get-Date $End -Format u)
+    It "Should have the correct upper bound" {
+        $Test    = $BatchBounds[-1].End
+        $Control = $End.ToString('u')
         $Test | Should -Be $Control
     }
 }


### PR DESCRIPTION
Fixes a series of off-by-one bugs & localization problems.
- Batch Bounds is now a rich object, get everything from colocated attributes
- Use `DateTimeOffset` soon & clobber UTC over client offset if present.
