### PR TITLE
Unixtime support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## 0.1.0
+
+Monday, 21st August, 2023
+
+- Adds support for the timestamp column to be numeric unix time

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -93,6 +93,7 @@ function Export-XbTable {
         $SleepSeconds = 120,
 
         [ValidateSet('second','millisecond')]
+        [AllowNull()]
         [string]
         $UnixTime,
 
@@ -182,15 +183,15 @@ function Export-XbTable {
             $TotalSerialMbPerSec = $ExportedMb / ($TotalMinutes * 60)
             $AverageMbPerSec = ($Batches | ForEach-Object {
                 $DurationSeconds = $_.Duration.TotalSeconds
-                if($DurationSeconds -eq 0){
-                    $null
+                if($DurationSeconds -gt 0){
+                    $_.SizeBytes / (1mb * $DurationSeconds)
                 } else {
-                    ($_.SizeBytes / 1mb) / $DurationSeconds
+                    $null
                 }
             } | Measure-Object -Average).Average
 
             $Status = @(
-                "Completed '$Parallel' batches for '$($Bounds[$IndexStart].Start)' to '$($Bounds[$IndexEnd].End)'. "
+                "Completed '$($Batches.Count)' batches for '$($Bounds[$IndexStart].Start)' to '$($Bounds[$IndexEnd].End)'. "
                 "- Exported Mb: '$ExportedMb'. "
                 "- Count blobs: '$BlobCount'. "
                 "- Serial export duration: '$WaitDurationStr'. "

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -92,6 +92,10 @@ function Export-XbTable {
         [int]
         $SleepSeconds = 120,
 
+        [ValidateSet('second','millisecond')]
+        [string]
+        $UnixTime,
+
         [switch]
         $NoExecute
     )
@@ -144,9 +148,11 @@ function Export-XbTable {
             $prefix   = $Bounds[$_].Label
             Write-Verbose "Initializing parallel batch; IndexPosition: '$_', Start: '$startStr', End: '$endStr'"
             if($DoExecute){
-                $Operation = Start-XbAsyncArchive -Start $startStr -End $endStr @AdxTableSpec
+                $Operation = Start-XbAsyncArchive -Start $startStr -End $endStr -UnixTime $UnixTime @AdxTableSpec
                 $Operation.Prefix = "${TimestampColumnName}=${prefix}"
                 $Operation
+            } else {
+                Start-XbAsyncArchive -Start $startStr -End $endStr -UnixTime $UnixTime @AdxTableSpec -NoExecute
             }
         }
 

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -76,6 +76,14 @@ function Start-XbAsyncArchive {
         "| where $TimestampColumnName <  $HighBound"
     ) -join "`n"
 
+    if($null -Ne 'UnixTime'){
+        $exportAsyncCmd += "`n"
+        $exportAsyncCmd += @(
+            "| extend ${TimestampColumnName}_DT = unixtime_${UnixTime}s_todatetime(${TimestampColumnName})"
+            "| project-reorder ${TimestampColumnName}_DT"
+        ) -join "`n"
+    }
+
     if($NoExecute){
         Write-Host $exportAsyncCmd
         return

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -44,15 +44,42 @@ function Start-XbAsyncArchive {
 
         [Parameter(Mandatory)]
         [string]
-        $TimestampColumnName
+        $TimestampColumnName,
+
+        [ValidateSet('second','millisecond')]
+        [AllowNull()]
+        [string]
+        $UnixTime,
+
+        [switch]
+        $NoExecute
     )
+
+    $UnixTime = $UnixTime.ToLower()
+    $EpochOffset = switch ($UnixTime) {
+        'Second'      { 62135596800 }
+        'Millisecond' { 62135596800000 }
+    }
+
+    if($null -Ne 'UnixTime'){
+        $LowBound = "tolong((datetime($startStr)/timespan(1 $UnixTime))-$EpochOffset)"
+        $HighBound = "tolong((datetime($endStr)/timespan(1 $UnixTime))-$EpochOffset)"
+    } else {
+        $LowBound = "datetime($startStr)"
+        $HighBound = "datetime($endStr)"
+    }
 
     $exportAsyncCmd = @(
         ".export async to table ext$TableName <|"
         "$TableName"
-        "| where $TimestampColumnName >= datetime($startStr)"
-        "| where $TimestampColumnName <  datetime($endStr)"
+        "| where $TimestampColumnName >= $LowBound"
+        "| where $TimestampColumnName <  $HighBound"
     ) -join "`n"
+
+    if($NoExecute){
+        Write-Host $exportAsyncCmd
+        return
+    }
 
     $AdxConnection = @{
         ClusterUrl = $ClusterUrl

--- a/PsAdxArchiver.psd1
+++ b/PsAdxArchiver.psd1
@@ -6,7 +6,7 @@
 
 @{
     RootModule = 'PsAdxArchiver.psm1'
-    ModuleVersion = '0.0.3'
+    ModuleVersion = '0.1.0'
     Guid = '6db49c4c-0073-44fe-95d8-907f056c1645'
     Author = 'Peter Vandivier'
     Copyright = '(c) Peter Vandivier. All rights reserved.'

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,6 +4,8 @@ Wrapper scripts to simplify export of a large table to azure blob storage.
 
 Assumes external table has already been provisioned.
 
+Requires that the table to be exported has some sort of timestamp column, either datetime or numeric unix time. 
+
 ## Stay Awake
 
 Because this module is designed to be long-running and bound to a laptop session, leveraging [PowerToys Awake](https://learn.microsoft.com/en-us/windows/powertoys/awake) is recommended.


### PR DESCRIPTION
In the event a source table uses a numeric Unix time attribute, the archiver now adds a computed column to the export query which maps to a `datetime` column added to the external table definition.

> :bug: :warning: There is a known bug in this release whereby blob tags are no longer applied.