### PR TITLE
Prefix support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 Thursday, 7th September, 2023
 
 - adds support for subdirectories in container path
+- bugfixes standard/non-UnixTime table DDL from New-XbTable
 
 ## 0.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Thursday, 7th September, 2023
 - bugfixes standard/non-UnixTime table DDL from New-XbTable
 - supports external name that does NOT exactly match source table
     - previously, the external table name needed to be exactly the source table name prefixed with "ext"
+- filters on known prefix to speed up pre-tag blob retreival in Receive phase
 
 ## 0.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.1
+
+Thursday, 7th September, 2023
+
+- adds support for subdirectories in container path
+
 ## 0.1.0
 
 Monday, 21st August, 2023

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ Thursday, 7th September, 2023
 
 - adds support for subdirectories in container path
 - bugfixes standard/non-UnixTime table DDL from New-XbTable
+- supports external name that does NOT exactly match source table
+    - previously, the external table name needed to be exactly the source table name prefixed with "ext"
 
 ## 0.1.0
 

--- a/Classes/XbAsyncExportWaiter.ps1
+++ b/Classes/XbAsyncExportWaiter.ps1
@@ -9,6 +9,7 @@ class XbAsyncExportWaiter {
     [ValidateNotNullOrEmpty()][string]$ClusterUrl
     [ValidateNotNullOrEmpty()][string]$DatabaseName
     [ValidateNotNullOrEmpty()][string]$TableName
+    [ValidateNotNullOrEmpty()][string]$ExternalTableName
     [ValidateNotNullOrEmpty()][string]$TimestampColumnName
     [string]$Prefix
     [ValidateNotNullOrEmpty()][guid]$OperationId
@@ -24,6 +25,7 @@ class XbAsyncExportWaiter {
         $this.ClusterUrl          = $InputObject.ClusterUrl
         $this.DatabaseName        = $InputObject.DatabaseName
         $this.TableName           = $InputObject.TableName
+        $this.ExternalTableName   = $InputObject.ExternalTableName
         $this.TimestampColumnName = $InputObject.TimestampColumnName
         $this.Prefix              = $InputObject.Prefix
         $this.OperationId         = $InputObject.OperationId

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -49,6 +49,11 @@ function Export-XbTable {
         [string]
         $TableName,
 
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ExternalTableName,
+
         [Parameter(Mandatory)]
         [string]
         $TimestampColumnName,
@@ -113,6 +118,7 @@ function Export-XbTable {
         ClusterUrl = $ClusterUrl
         DatabaseName = $DatabaseName
         TableName = $TableName
+        ExternalTableName = $ExternalTableName
         TimestampColumnName = $TimestampColumnName
     }
 

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -63,6 +63,11 @@ function Export-XbTable {
         [string]
         $TimestampColumnName,
 
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $PathFormatColumnName,
+
         [Parameter(
             Mandatory,
             ParameterSetName='Timespan'
@@ -157,8 +162,12 @@ function Export-XbTable {
         $Batches = $IndexStart .. $IndexEnd | ForEach-Object {
             $startStr = $Bounds[$_].Start
             $endStr   = $Bounds[$_].End
-            $label   = $Bounds[$_].Label
-            $prefix   = "${TimestampColumnName}=${label}"
+            $label    = $Bounds[$_].Label
+            if($PsBoundParameters.Keys.Contains('PathFormatColumnName')){
+                $prefix = "${PathFormatColumnName}=${label}"
+            } else {
+                $prefix = "${TimestampColumnName}=${label}"
+            }
             if($PsBoundParameters.Keys.Contains('Directory')){
                 $prefix = "$Directory/$prefix"
             }

--- a/Functions/Export-XbTable.ps1
+++ b/Functions/Export-XbTable.ps1
@@ -33,6 +33,11 @@ function Export-XbTable {
         $Container,
 
         [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Directory,
+
+        [Parameter()]
         [string]
         $LogFile,
 
@@ -152,11 +157,15 @@ function Export-XbTable {
         $Batches = $IndexStart .. $IndexEnd | ForEach-Object {
             $startStr = $Bounds[$_].Start
             $endStr   = $Bounds[$_].End
-            $prefix   = $Bounds[$_].Label
+            $label   = $Bounds[$_].Label
+            $prefix   = "${TimestampColumnName}=${label}"
+            if($PsBoundParameters.Keys.Contains('Directory')){
+                $prefix = "$Directory/$prefix"
+            }
             Write-Verbose "Initializing parallel batch; IndexPosition: '$_', Start: '$startStr', End: '$endStr'"
             if($DoExecute){
                 $Operation = Start-XbAsyncArchive -Start $startStr -End $endStr -UnixTime $UnixTime @AdxTableSpec
-                $Operation.Prefix = "${TimestampColumnName}=${prefix}"
+                $Operation.Prefix = $prefix
                 $Operation
             } else {
                 Start-XbAsyncArchive -Start $startStr -End $endStr -UnixTime $UnixTime @AdxTableSpec -NoExecute

--- a/Functions/New-XbTable.ps1
+++ b/Functions/New-XbTable.ps1
@@ -41,6 +41,11 @@ function New-XbTable {
         [string]
         $TableName,
 
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ExternalTableName,
+
         [Parameter(Mandatory)]
         [string]
         $TimestampColumnName,
@@ -76,6 +81,11 @@ function New-XbTable {
 
     $TableSchema = Invoke-AdxCmd @Connection -Command ".show table ['$TableName'] cslschema"
 
+    if($PsBoundParameters.Keys -contains 'ExternalTableName'){
+        $TableSchema.TableName = $ExternalTableName
+    } else {
+    }
+    
     $TableSchema.TableName = "ext${TableName}"
     $TableSchema.Folder = $null
     $TableSchema.DocString = $null

--- a/Functions/New-XbTable.ps1
+++ b/Functions/New-XbTable.ps1
@@ -24,6 +24,10 @@ function New-XbTable {
         [string]
         $Container,
 
+        [Parameter()]
+        [string]
+        $Prefix,
+
         [Parameter(Mandatory)]
         [ValidateScript({$_.EndsWith(';Fed=True')})]
         [string]
@@ -87,6 +91,12 @@ function New-XbTable {
         $PathFormat = "pathformat = (`"${TimestampColumnName}_DT=`" datetime_pattern(`"yyyy-MM-dd`", ${TimestampColumnName}_DT))"
     }
 
+    if([string]::IsNullOrEmpty($Prefix)){
+        $UriPath = $Container
+    } else {
+        $UriPath = "$Container/$Prefix"
+    }
+
     $TableDdl += @(
         ""
         "kind = blob "
@@ -94,7 +104,7 @@ function New-XbTable {
         "$PathFormat"
         "dataformat = parquet "
         "("
-        "    h@'https://${StorageAccountName}.blob.core.windows.net/${Container}/;${AccessKey}' " 
+        "    h@'https://${StorageAccountName}.blob.core.windows.net/${UriPath}/;${AccessKey}' " 
         ") "
         "with ( "
         "    compressed = true,"

--- a/Functions/New-XbTable.ps1
+++ b/Functions/New-XbTable.ps1
@@ -84,9 +84,9 @@ function New-XbTable {
     if($PsBoundParameters.Keys -contains 'ExternalTableName'){
         $TableSchema.TableName = $ExternalTableName
     } else {
+        $TableSchema.TableName = "ext${TableName}"
     }
     
-    $TableSchema.TableName = "ext${TableName}"
     $TableSchema.Folder = $null
     $TableSchema.DocString = $null
 

--- a/Functions/New-XbTable.ps1
+++ b/Functions/New-XbTable.ps1
@@ -26,7 +26,7 @@ function New-XbTable {
 
         [Parameter()]
         [string]
-        $Prefix,
+        $Directory,
 
         [Parameter(Mandatory)]
         [ValidateScript({$_.EndsWith(';Fed=True')})]
@@ -101,10 +101,10 @@ function New-XbTable {
         $PathFormat = "pathformat = (`"${TimestampColumnName}_DT=`" datetime_pattern(`"yyyy-MM-dd`", ${TimestampColumnName}_DT))"
     }
 
-    if([string]::IsNullOrEmpty($Prefix)){
+    if([string]::IsNullOrEmpty($Directory)){
         $UriPath = $Container
     } else {
-        $UriPath = "$Container/$Prefix"
+        $UriPath = "$Container/$Directory"
     }
 
     $TableDdl += @(

--- a/Functions/Receive-XbAsyncArchive.ps1
+++ b/Functions/Receive-XbAsyncArchive.ps1
@@ -43,7 +43,7 @@ function Receive-XbAsyncArchive {
 
     $Context = New-AzStorageContext -StorageAccountName $StorageAccountName -UseConnectedAccount
 
-    $Blobs = $Context | Get-AzStorageBlob -Container $Container | Where-Object { 
+    $Blobs = $Context | Get-AzStorageBlob -Container $Container -Prefix $Waiter.Prefix | Where-Object { 
         $_.Name -in $ResultBlobs.Name
     }
 

--- a/Functions/Receive-XbAsyncArchive.ps1
+++ b/Functions/Receive-XbAsyncArchive.ps1
@@ -56,7 +56,11 @@ function Receive-XbAsyncArchive {
             RowCount = $ResultBlob.RowCount.ToString()
             SizeInBytes = $ResultBlob.SizeInBytes.ToString()
         }
-        Set-AzStorageBlobTag -Tag $Tags -Container $Container -Blob $blob.Name -Context $Context | Out-Null
+        if($Waiter.Prefix.Contains("/")){
+            Write-Warning "Blob API is not yet supported for hierarchical namespace accounts. Skipping tagging."
+        }else{
+            Set-AzStorageBlobTag -Tag $Tags -Container $Container -Blob $blob.Name -Context $Context | Out-Null
+        }
     }
 
     $Aggregate = $Blobs | ForEach-Object {$_.Length} | Measure-Object -Sum 

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -46,8 +46,9 @@ function Start-XbAsyncArchive {
         [string]
         $TimestampColumnName,
 
-        [ValidateSet('second','millisecond')]
+        [ValidateSet('second','millisecond','')]
         [AllowNull()]
+        [AllowEmptyString()]
         [string]
         $UnixTime,
 
@@ -57,11 +58,11 @@ function Start-XbAsyncArchive {
 
     $UnixTime = $UnixTime.ToLower()
     $EpochOffset = switch ($UnixTime) {
-        'Second'      { 62135596800 }
-        'Millisecond' { 62135596800000 }
+        'second'      { 62135596800 }
+        'millisecond' { 62135596800000 }
     }
 
-    if($null -Ne 'UnixTime'){
+    if(-not [string]::IsNullOrEmpty($UnixTime)){
         $LowBound = "tolong((datetime($startStr)/timespan(1 $UnixTime))-$EpochOffset)"
         $HighBound = "tolong((datetime($endStr)/timespan(1 $UnixTime))-$EpochOffset)"
     } else {
@@ -76,7 +77,7 @@ function Start-XbAsyncArchive {
         "| where $TimestampColumnName <  $HighBound"
     ) -join "`n"
 
-    if($null -Ne 'UnixTime'){
+    if(-not [string]::IsNullOrEmpty($UnixTime)){
         $exportAsyncCmd += "`n"
         $exportAsyncCmd += @(
             "| extend ${TimestampColumnName}_DT = unixtime_${UnixTime}s_todatetime(${TimestampColumnName})"

--- a/Functions/Start-XbAsyncArchive.ps1
+++ b/Functions/Start-XbAsyncArchive.ps1
@@ -42,6 +42,10 @@ function Start-XbAsyncArchive {
         [string]
         $TableName,
 
+        [Parameter()]
+        [string]
+        $ExternalTableName,
+
         [Parameter(Mandatory)]
         [string]
         $TimestampColumnName,
@@ -70,8 +74,12 @@ function Start-XbAsyncArchive {
         $HighBound = "datetime($endStr)"
     }
 
+    if([string]::IsNullOrEmpty($ExternalTableName)){
+        $ExternalTableName = "ext$TableName"
+    }
+
     $exportAsyncCmd = @(
-        ".export async to table ext$TableName <|"
+        ".export async to table $ExternalTableName <|"
         "$TableName"
         "| where $TimestampColumnName >= $LowBound"
         "| where $TimestampColumnName <  $HighBound"
@@ -114,6 +122,7 @@ function Start-XbAsyncArchive {
         ClusterUrl          = $ClusterUrl
         DatabaseName        = $DatabaseName
         TableName           = $TableName
+        ExternalTableName   = $ExternalTableName
         TimestampColumnName = $TimestampColumnName 
         OperationId         = $command.OperationId
     }

--- a/Functions/Wait-XbAsyncArchive.ps1
+++ b/Functions/Wait-XbAsyncArchive.ps1
@@ -61,6 +61,7 @@ function Wait-XbAsyncArchive {
                 break 
             }
         }
+
         $Waiter.State = $operation.State
         $Waiter.Duration = $operation.Duration
         $Waiter

--- a/PsAdxArchiver.psd1
+++ b/PsAdxArchiver.psd1
@@ -6,7 +6,7 @@
 
 @{
     RootModule = 'PsAdxArchiver.psm1'
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.1.1'
     Guid = '6db49c4c-0073-44fe-95d8-907f056c1645'
     Author = 'Peter Vandivier'
     Copyright = '(c) Peter Vandivier. All rights reserved.'


### PR DESCRIPTION
- Supports custom external naming
- Retreiving a big list of blobs can take a long time & slow you down. Only list the blobs you need to tag
- Allows limited custom [`pathformat`](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/management/external-tables-azurestorage-azuredatalake#path-format) support
- Supports nesting blobs in subdirectories...
```diff
- ⚠ HOWEVER ⚠
```
- ...you cannot tag a blob in a folder, so don't try
  - `BlobApiNotYetSupportedForHierarchicalNamespaceAccounts`
